### PR TITLE
template: Possibility to have multiple parameters with same name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,8 @@ sphinx_sources:
       name: "test_source"
       type: "xmlpipe2"
       xmlpipe_command: "cat /tmp/test.xml"
+      sql_attr_timestamp: [ param1, param2 ]
+      sql_attr_float: [ param3, param4 ]
 
 sphinx_indexes:
   - index:

--- a/templates/conf.d_sources.conf.jn2
+++ b/templates/conf.d_sources.conf.jn2
@@ -3,8 +3,12 @@
 source {{ item.source.name }}
 {
 {% for k,v in item.source.iteritems() %}
-{% if k != 'name' %}
+{% if k != 'name' and v is string %}
   {{ k }} = {{ v }}
+{% elif v is iterable and v is not string %}
+{% for item in v %}
+  {{ k }} = {{ item }}
+{% endfor %}
 {% endif %}
 {% endfor %}
 }


### PR DESCRIPTION
In sphinx it is allowed to have some parameters with the same name
multiple times, sql_attr_timestamp, sql_attr_float etc. Due to the
current way the template was generated that wasn't possible, because the
yaml would over-write the variable's value.

Giving some more 'intelligence' to the template, and make it checks the
type 'string' or 'list' allow now to do so. Default variable have been
modified to reflect those changes.

Fixes https://github.com/devjatkin/sphinx/issues/6