### PR TITLE
Replace dict.iteritems with dict.items

### DIFF
--- a/templates/conf.d_indexer.conf.jn2
+++ b/templates/conf.d_indexer.conf.jn2
@@ -1,6 +1,6 @@
 indexer
 {
-{% for k,v in sphinx_indexer.iteritems() %}
+{% for k,v in sphinx_indexer.items() %}
   {{ k }} = {{ v }}
 {% endfor %}
 }

--- a/templates/conf.d_indexes.conf.jn2
+++ b/templates/conf.d_indexes.conf.jn2
@@ -2,7 +2,7 @@
 {% for item in sphinx_indexes %}
 index {{ item.index.name }}
 {
-{% for k,v in item.index.iteritems() %}
+{% for k,v in item.index.items() %}
 {% if k != 'name' %}
   {{ k }} = {{ v }}
 {% endif %}

--- a/templates/conf.d_searchd.conf.jn2
+++ b/templates/conf.d_searchd.conf.jn2
@@ -3,7 +3,7 @@ searchd
 {% for a in sphinx_searchd.listen %}
   listen = {{a}}
 {% endfor %}
-{% for k,v in sphinx_searchd.iteritems() %}
+{% for k,v in sphinx_searchd.items() %}
 {% if k != 'listen' %}
   {{ k }} = {{ v }}
 {% endif %}

--- a/templates/conf.d_sources.conf.jn2
+++ b/templates/conf.d_sources.conf.jn2
@@ -2,7 +2,7 @@
 {% for item in sphinx_sources %}
 source {{ item.source.name }}
 {
-{% for k,v in item.source.iteritems() %}
+{% for k,v in item.source.items() %}
 {% if k != 'name' and v is string %}
   {{ k }} = {{ v }}
 {% elif v is iterable and v is not string %}


### PR DESCRIPTION
According to https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-dict-iteritems.html

> The dict.iteritems method has been removed in Python 3

This causes the various configuration files created from `ext_config.yml` to fail with

```
fatal: [next.donalo.org]: FAILED! => {
    "changed": false,
    "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'"
}
```

Since we're running Ansible with Python 3, we could claim this PR brings support for it. I still need to see an execution with no failures to confirm it though.