### PR TITLE
Multiple attributes with the same name in indexes

### DIFF
--- a/templates/conf.d_indexes.conf.jn2
+++ b/templates/conf.d_indexes.conf.jn2
@@ -3,8 +3,12 @@
 index {{ item.index.name }}
 {
 {% for k,v in item.index.items() %}
-{% if k != 'name' %}
+{% if k != 'name' and v is string %}
   {{ k }} = {{ v }}
+{% elif v is iterable and v is not string %}
+{% for item in v %}
+  {{ k }} = {{ item }}
+{% endfor %}
 {% endif %}
 {% endfor %}
 }


### PR DESCRIPTION
This resolves similar issue to https://github.com/devjatkin/sphinx/issues/6
Currently it is not possible to define indexes with for example mutliple fields.