### PR TITLE
dont fail rotate when there is no indexes

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,8 @@
 
 - name: rotate all indexes
   command: /usr/bin/indexer --rotate --all
+  register: rotate_result
+  failed_when: "rotate_result.rc > 0 and 'no indexes found' not in rotate_result.stdout"
 
 - name: restart sphinx
   service: name="{{ sphinx_service_name }}" state=restarted


### PR DESCRIPTION
Basically if there is only real-time indexes or no indexes configured whole playbook will fail.
I've created some fix for this.